### PR TITLE
Log MQTT connection failures

### DIFF
--- a/src/main/java/org/traccar/forward/MqttClient.java
+++ b/src/main/java/org/traccar/forward/MqttClient.java
@@ -27,7 +27,12 @@ import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
 import com.hivemq.client.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PublishResult;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class MqttClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MqttClient.class);
 
     private final Mqtt5AsyncClient client;
 
@@ -48,7 +53,9 @@ public class MqttClient {
 
         client = builder.buildAsync();
         client.connectWith().send().whenComplete((message, e) -> {
-            throw new RuntimeException(e);
+            if (e != null) {
+                LOGGER.warn("MQTT connection failed", e);
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- avoid unhandled exceptions in MQTT client by logging connection errors instead of throwing

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c01d07299883278283f6fd8ff5a149